### PR TITLE
Add support for integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v2.4.0
 
-      - name: Setup Java
+      - name: Setup Java 17
         uses: actions/setup-java@v2.5.0
         with:
           distribution: adopt
@@ -25,11 +25,11 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build
-        run: ./gradlew projects clean build jacocoTestReport --no-daemon --refresh-dependencies
+        run: ./gradlew projects clean build --no-daemon --refresh-dependencies
 
-      - name: Upload coverage to Codecov
+      - name: Upload coverage to Codecov (Linux only)
         if: matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v2.1.0
         with:
-          flags: unittests
+          flags: unit-tests
           fail_ci_if_error: true

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,35 @@
+name: integration-test
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  integration-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2.4.0
+
+      - name: Setup Java 17
+        uses: actions/setup-java@v2.5.0
+        with:
+          distribution: adopt
+          java-version: 17
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Integration Test
+        run: ./gradlew projects clean integrationTest --no-daemon --refresh-dependencies
+
+      - name: Upload coverage to Codecov (Linux only)
+        if: matrix.os == 'ubuntu-latest'
+        uses: codecov/codecov-action@v2.1.0
+        with:
+          flags: integration-tests
+          fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ template repository for Java projects using Gradle
 - Rename the root project (currently `java-gradle-template`) and group (currently `com.wilmol`) to your liking
 - Delete anything you won't use (sub projects, dependencies, etc.)
 - Update the README
+- Other non-code setup like your GitHub branch protections
 
 ### Build and test
 

--- a/README.md
+++ b/README.md
@@ -1,36 +1,40 @@
 # java-gradle-template
 
-[![build](https://github.com/wilmol/java-gradle-template/workflows/build/badge.svg?event=push)](https://github.com/wilmol/java-gradle-template/actions?query=workflow%3Abuild)
+[![build](https://github.com/wilmol/java-gradle-template/workflows/build/badge.svg?branch=main&event=push)](https://github.com/wilmol/java-gradle-template/actions?query=workflow%3Abuild)
+[![integration-test](https://github.com/wilmol/java-gradle-template/workflows/integration-test/badge.svg?branch=main&event=push)](https://github.com/wilmol/java-gradle-template/actions?query=workflow%3Aintegration-test)
 [![codecov](https://codecov.io/gh/wilmol/java-gradle-template/branch/main/graph/badge.svg)](https://codecov.io/gh/wilmol/java-gradle-template)
 
 template repository for Java projects using Gradle
 
-## Usage
-* Just go to: https://github.com/wilmol/java-gradle-template/generate
-  * This will prompt you to create a new repository with all the files setup
-* Rename the root project (currently `java-gradle-template`) and group (currently `com.wilmol`) to your liking 
-* Create your README
-* Delete anything you won't use (sub projects, dependencies etc.)
-
-### Build
-```
-./gradlew spotlessApply build
-```
-
 ## Features
-* Java 17 LTS
-* Gradle 7
-  * Multi-project builds
-* [GitHub Actions CI](https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle) integration
-* [Codecov](https://codecov.io/) integration
-* [Spotless](https://github.com/diffplug/spotless) integration 
-  * With [google-java-format](https://github.com/google/google-java-format)
-* [Checkstyle](https://github.com/checkstyle/checkstyle) integration 
-  * With [google_checks](https://github.com/checkstyle/checkstyle/blob/master/src/main/resources/google_checks.xml)
-* [SpotBugs](https://spotbugs.github.io/) integration
+
+- Java 17
+- Gradle 7
+- [GitHub Actions](https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle) CICD
+- Automatic code formatting via [Spotless](https://github.com/diffplug/spotless)
+- Code style analysis via [Checkstyle](https://github.com/checkstyle/checkstyle)
+- Static analysis via [SpotBugs](https://spotbugs.github.io/)
+- Unit and integration test support via JUnit 5 and [TestSets plugin](https://github.com/unbroken-dome/gradle-testsets-plugin)
+- Code coverage reporting via [Codecov](https://codecov.io/)
+
+## Usage
+
+- Click [Use this template](https://github.com/wilmol/java-gradle-template/generate)
+  - This will prompt you to create a new repository with all the files setup
+- Rename the root project (currently `java-gradle-template`) and group (currently `com.wilmol`) to your liking
+- Delete anything you won't use (sub projects, dependencies, etc.)
+- Update the README
+
+### Build and test
+
+```
+./gradlew spotlessApply build integrationTest
+```
 
 ## Promise
-* Keep up to date with:
-  * Future Java versions
-  * Future Gradle versions
-  * Other dependency upgrades
+
+- Keep up to date with:
+  - Future Java versions
+  - Future Gradle versions
+  - Other dependency upgrades
+  - Any other cool tools or plugins

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,7 @@ buildscript {
     classpath group: 'com.diffplug.spotless', name: 'spotless-plugin-gradle', version: '6.0.5'
     classpath group: 'gradle.plugin.com.github.spotbugs.snom', name: 'spotbugs-gradle-plugin', version: '4.7.5'
     classpath group: 'net.rdrei.android.buildtimetracker', name: 'gradle-plugin', version: '0.11.1'
+    classpath group: 'org.unbroken-dome.gradle-plugins', name: 'gradle-testsets-plugin', version: '4.0.0'
   }
 }
 
@@ -102,14 +103,21 @@ subprojects {
 
   // JaCoCo (code coverage reporting)
   apply plugin: 'jacoco'
-  jacocoTestReport {
+  tasks.withType(JacocoReport) {
     reports {
       xml.enabled = true
       html.enabled = true
       csv.enabled = false
     }
   }
-  check.dependsOn jacocoTestReport
+  test.finalizedBy jacocoTestReport
+
+  // Integration test support
+  apply plugin: 'org.unbroken-dome.test-sets'
+  testSets {
+    integrationTest
+  }
+  integrationTest.finalizedBy jacocoIntegrationTestReport
 
   // pin dependency versions
   ext {
@@ -127,6 +135,7 @@ subprojects {
     implementation group: 'com.google.guava', name: 'guava', version: "$guavaVersion"
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: "$log4jVersion"
     implementation group: 'com.github.spotbugs', name: 'spotbugs-annotations', version: '4.5.2'
+    implementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
 
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: "$junitVersion"
     testImplementation group: 'com.google.truth', name: 'truth', version: "$truthVersion"

--- a/hello-world/src/integrationTest/java/com/wilmol/HelloWorldIntegrationTest.java
+++ b/hello-world/src/integrationTest/java/com/wilmol/HelloWorldIntegrationTest.java
@@ -5,11 +5,11 @@ import static com.google.common.truth.Truth.assertThat;
 import org.junit.jupiter.api.Test;
 
 /**
- * Example unit test.
+ * Example integration test.
  *
  * @author <a href=https://wilmol.com>Will Molloy</a>
  */
-class HelloWorldTest {
+class HelloWorldIntegrationTest {
 
   @Test
   void test() {


### PR DESCRIPTION
Add support for integration tests via gradle TestSets plugin.

Add CI job.

Ensure code coverage is reported (separate `unit-tests` and `integration-tests` flags).